### PR TITLE
Externalize dependencies in esm bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "types": "./types/index.d.ts",
   "scripts": {
     "bundle:global": "esbuild src/index.js --global-name=OnigurumaToES --bundle --minify --sourcemap --outfile=dist/index.min.js",
-    "bundle:esm": "esbuild src/index.js --format=esm --bundle --sourcemap --outfile=dist/index.mjs",
+    "bundle:esm": "esbuild src/index.js --format=esm --bundle --sourcemap --external:emoji-regex-xs --external:regex --external:regex-recursion --outfile=dist/index.mjs",
     "types": "tsc src/index.js --rootDir src --declaration --allowJs --emitDeclarationOnly --outDir types",
     "prebuild": "rm -rf dist/* types/*",
     "build": "pnpm run bundle:global && pnpm run bundle:esm && pnpm run types",


### PR DESCRIPTION
Not sure if it's intentional, but since `emoji-regex-xs`, `regex` and `regex-recursion` is already part of the dependencies list, the bundled code could externalize them to import the packages as is.