### PR TITLE
feat: expose raw options on `EmulatedRegExp`

### DIFF
--- a/src/subclass.js
+++ b/src/subclass.js
@@ -16,6 +16,7 @@ results from `toDetails` to produce the same result as `toRegExp`.
 */
 class EmulatedRegExp extends RegExpSubclass {
   #strategy;
+  rawOptions;
   /**
   @param {string | EmulatedRegExp} pattern
   @param {string} [flags]
@@ -36,6 +37,7 @@ class EmulatedRegExp extends RegExpSubclass {
       // Can read private properties of the existing object since it was created by this class
       this.#strategy = pattern.#strategy;
     }
+    this.rawOptions = options;
   }
   /**
   Called internally by all String/RegExp methods that use regexes.


### PR DESCRIPTION
I would need this for https://github.com/shikijs/shiki/issues/878 where I can serialized it into JS code with like:

```ts
// pseudo code
let jsCode = ''

for (const reg of regexps) {
  if (reg instance of EmulatedRegExp)
    jsCode += `new EmulatedRegExp(${JSON.stringify(reg.source)},${JSON.stringify(reg.flags)},${JSON.stringify(reg.rawOptions)})`
}
```