### PR TITLE
Vend CommonJS module as well as ESM (dual vend)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,17 +8,20 @@
   "exports": {
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./dist/index.mjs"
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js"
     }
   },
   "browser": "./dist/index.min.js",
+  "main": "./dist/cjs/index.js",
   "types": "./types/index.d.ts",
   "scripts": {
     "bundle:global": "esbuild src/index.js --global-name=OnigurumaToES --bundle --minify --sourcemap --outfile=dist/index.min.js",
-    "bundle:esm": "esbuild src/index.js --format=esm --bundle --sourcemap --external:emoji-regex-xs --external:regex --external:regex-recursion --outfile=dist/index.mjs",
+    "bundle:esm": "esbuild src/index.js --format=esm --bundle --sourcemap --outfile=dist/esm/index.mjs",
+    "bundle:cjs": "esbuild src/index.js --format=cjs --bundle --sourcemap --outfile=dist/cjs/index.js",
     "types": "tsc src/index.js --rootDir src --declaration --allowJs --emitDeclarationOnly --outDir types",
     "prebuild": "rm -rf dist/* types/*",
-    "build": "pnpm run bundle:global && pnpm run bundle:esm && pnpm run types",
+    "build": "pnpm run bundle:global && pnpm run bundle:esm && pnpm run bundle:cjs && pnpm run types",
     "pretest": "pnpm run build",
     "test": "jasmine",
     "onig:compare": "node scripts/onig-compare.js",

--- a/spec/emulatedregexp.spec.js
+++ b/spec/emulatedregexp.spec.js
@@ -1,4 +1,4 @@
-import {EmulatedRegExp, toRegExp} from '../dist/index.mjs';
+import {EmulatedRegExp, toRegExp} from '../dist/esm/index.mjs';
 import {envSupportsFlagV, r} from '../src/utils.js';
 import {emulationGroupMarker} from 'regex/internals';
 

--- a/spec/helpers/matchers.js
+++ b/spec/helpers/matchers.js
@@ -1,4 +1,4 @@
-import {toRegExp} from '../../dist/index.mjs';
+import {toRegExp} from '../../dist/esm/index.mjs';
 import {EsVersion} from '../../src/options.js';
 
 function getArgs(actual, expected) {

--- a/spec/match-assertion.spec.js
+++ b/spec/match-assertion.spec.js
@@ -1,4 +1,4 @@
-import {toDetails, toRegExp} from '../dist/index.mjs';
+import {toDetails, toRegExp} from '../dist/esm/index.mjs';
 import {r} from '../src/utils.js';
 import {matchers} from './helpers/matchers.js';
 

--- a/spec/match-backreference.spec.js
+++ b/spec/match-backreference.spec.js
@@ -1,4 +1,4 @@
-import {toDetails} from '../dist/index.mjs';
+import {toDetails} from '../dist/esm/index.mjs';
 import {cp, r} from '../src/utils.js';
 import {maxTestTargetForFlagGroups, minTestTargetForFlagGroups} from './helpers/features.js';
 import {matchers} from './helpers/matchers.js';

--- a/spec/match-capturing-group.spec.js
+++ b/spec/match-capturing-group.spec.js
@@ -1,4 +1,4 @@
-import {toDetails, toRegExp} from '../dist/index.mjs';
+import {toDetails, toRegExp} from '../dist/esm/index.mjs';
 import {matchers} from './helpers/matchers.js';
 
 beforeEach(() => {

--- a/spec/match-char-class-intersection.spec.js
+++ b/spec/match-char-class-intersection.spec.js
@@ -1,4 +1,4 @@
-import {toDetails} from '../dist/index.mjs';
+import {toDetails} from '../dist/esm/index.mjs';
 import {r} from '../src/utils.js';
 import {minTestTargetForFlagV} from './helpers/features.js';
 import {matchers} from './helpers/matchers.js';

--- a/spec/match-char-class-range.spec.js
+++ b/spec/match-char-class-range.spec.js
@@ -1,4 +1,4 @@
-import {toDetails} from '../dist/index.mjs';
+import {toDetails} from '../dist/esm/index.mjs';
 import {r} from '../src/utils.js';
 import {minTestTargetForFlagV} from './helpers/features.js';
 import {matchers} from './helpers/matchers.js';

--- a/spec/match-char-class.spec.js
+++ b/spec/match-char-class.spec.js
@@ -1,4 +1,4 @@
-import {toDetails} from '../dist/index.mjs';
+import {toDetails} from '../dist/esm/index.mjs';
 
 describe('CharacterClass', () => {
   // See also `match-char-class-range.spec.js` and `match-char-class-intersection.spec.js`

--- a/spec/match-char-set.spec.js
+++ b/spec/match-char-set.spec.js
@@ -1,4 +1,4 @@
-import {toDetails, toRegExp} from '../dist/index.mjs';
+import {toDetails, toRegExp} from '../dist/esm/index.mjs';
 import {r} from '../src/utils.js';
 import {maxTestTargetForFlagGroups} from './helpers/features.js';
 import {matchers} from './helpers/matchers.js';

--- a/spec/match-char.spec.js
+++ b/spec/match-char.spec.js
@@ -1,4 +1,4 @@
-import {toDetails} from '../dist/index.mjs';
+import {toDetails} from '../dist/esm/index.mjs';
 import {cp, r} from '../src/utils.js';
 import {matchers} from './helpers/matchers.js';
 

--- a/spec/match-lookaround.spec.js
+++ b/spec/match-lookaround.spec.js
@@ -1,4 +1,4 @@
-import {toDetails} from '../dist/index.mjs';
+import {toDetails} from '../dist/esm/index.mjs';
 import {matchers} from './helpers/matchers.js';
 
 beforeEach(() => {

--- a/spec/match-quantifier.spec.js
+++ b/spec/match-quantifier.spec.js
@@ -1,4 +1,4 @@
-import {toDetails} from '../dist/index.mjs';
+import {toDetails} from '../dist/esm/index.mjs';
 import {r} from '../src/utils.js';
 import {matchers} from './helpers/matchers.js';
 

--- a/spec/match-recursion.spec.js
+++ b/spec/match-recursion.spec.js
@@ -1,4 +1,4 @@
-import {toDetails, toRegExp} from '../dist/index.mjs';
+import {toDetails, toRegExp} from '../dist/esm/index.mjs';
 import {r} from '../src/utils.js';
 import {matchers} from './helpers/matchers.js';
 

--- a/spec/match-search-start.spec.js
+++ b/spec/match-search-start.spec.js
@@ -1,4 +1,4 @@
-import {toDetails, toRegExp} from '../dist/index.mjs';
+import {toDetails, toRegExp} from '../dist/esm/index.mjs';
 import {r} from '../src/utils.js';
 import {maxTestTargetForFlagGroups} from './helpers/features.js';
 import {matchers} from './helpers/matchers.js';

--- a/spec/match-subroutine.spec.js
+++ b/spec/match-subroutine.spec.js
@@ -1,4 +1,4 @@
-import {toDetails, toRegExp} from '../dist/index.mjs';
+import {toDetails, toRegExp} from '../dist/esm/index.mjs';
 import {r} from '../src/utils.js';
 import {matchers} from './helpers/matchers.js';
 

--- a/spec/options.spec.js
+++ b/spec/options.spec.js
@@ -1,4 +1,4 @@
-import {toDetails} from '../dist/index.mjs';
+import {toDetails} from '../dist/esm/index.mjs';
 import {envSupportsFlagV, r} from '../src/utils.js';
 import {matchers} from './helpers/matchers.js';
 

--- a/spec/todetails.spec.js
+++ b/spec/todetails.spec.js
@@ -1,4 +1,4 @@
-import {toDetails} from '../dist/index.mjs';
+import {toDetails} from '../dist/esm/index.mjs';
 import {r} from '../src/utils.js';
 
 describe('toDetails', () => {


### PR DESCRIPTION
# Description

Per the discussion in https://github.com/slevithan/oniguruma-to-es/issues/26, this PR configures the module to vend a CommonJS (CJS) module as well as an ESM module.

I followed the example of https://github.com/slevithan/regex, which is another one of Steven's libraries that is dual-vended already and also is a dependency of this one, as closely as possible, while making what I hope is the minimum number of edits and changes.

# Testing

```shell
$ pnpm run build
```