### PR TITLE
fix: Use `globalThis` to prevent environment check code from being re…

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -5,8 +5,9 @@ const r = String.raw;
 
 const envFlags = {
   flagGroups: (() => {
+    // Use globalThis to prevent being removed during bundling with Rolldown.
     try {
-      new RegExp('(?i:)');
+      new globalThis.RegExp('(?i:)');
     } catch {
       return false;
     }
@@ -16,7 +17,7 @@ const envFlags = {
     try {
       // Check for flag v support and also that nested classes can be parsed
       // See <github.com/slevithan/oniguruma-to-es/pull/41>
-      new RegExp('[[]]', 'v');
+      new globalThis.RegExp('[[]]', 'v');
     } catch {
       return false;
     }


### PR DESCRIPTION
fix #42

When bundling with Rolldown or tsdown, enabling code minification (compression) or tree-shaking (pruning) will cause the environment check code to be removed.

> Works fine with esbuild and Rollup, they won’t remove it.

Before bundling
```javascript
var envFlags = {
  flagGroups: (() => {
    try {
      new RegExp("(?i:)");
    } catch {
      return false;
    }
    return true;
  })(),
  unicodeSets: (() => {
    try {
      new RegExp("[[]]", "v");
    } catch {
      return false;
    }
    return true;
  })()
};
```

After bundling
```javascript
var envFlags = {
  flagGroups: true,
  unicodeSets: true
};
```

Replacing `RegExp` with `globalThis.RegExp` can prevent this behavior.